### PR TITLE
3.5 new App widget

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,17 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
+}
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: MySecondWidget(),
+      title: "Sample title",
+    );
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -138,10 +148,17 @@ class MySecondWidget extends StatefulWidget {
 class _MySecondWidgetState extends State<MySecondWidget> {
   int cnt = 0;
 
+  Type getContext() {
+    return context.runtimeType;
+  }
+
   @override
   Widget build(BuildContext context) {
     ++cnt;
     print(cnt);
+
+    print(getContext());
+
     return Container(
       child: Center(
         child: Text("Hello!"),


### PR DESCRIPTION
Flutter хочет использовать main.dart как точку входа, судя по всему это можно изменить через передачу дополнительных аргументов в командной строке, либо в IDE.
Значение поля title можно увидеть, если открыть список запущенных приложений (с миниатюрами).
Метод возвращающий context.runtimeType можно написать только в StatefulWidget, потому что State содержит проперти context, а StatelessWidget - нет, поэтому из метода не принимающего аргументы никак не получить context.